### PR TITLE
PHP signature issue with openssl_sign which is fixed which returns bo…

### DIFF
--- a/php/SaltEdge.php
+++ b/php/SaltEdge.php
@@ -136,13 +136,12 @@ class SaltEdge
         $payload = is_string($payload) ? $payload : json_encode($payload);
 
         // Prepare the signature
-        $signature = $expires . "|" . $method . "|" . $url . "|" . $payload;
-        $signatureCipher = "";
+        $data = $expires . "|" . $method . "|" . $url . "|" . $payload;
 
         // Sign the data
         $signingResult = openssl_sign(
+          $data,
           $signature,
-          $signatureCipher,
           $this->privateKey,
           OPENSSL_ALGO_SHA256
         );
@@ -153,7 +152,7 @@ class SaltEdge
         }
 
         // The signature should be a base64 encoded string
-        $signingResult = base64_encode($signingResult);
+        $signature = base64_encode($signature);
 
         // Prepare curl options
         $curlOptions = array(
@@ -161,7 +160,7 @@ class SaltEdge
             CURLOPT_HTTPHEADER => array(
                 "Content-Type: application/json",
                 "Expires-at: {$expires}",
-                "Signature: {$signingResult}",
+                "Signature: {$signature}",
                 "App-id: {$this->appId}",
                 "Secret: {$this->secret}",
             ),


### PR DESCRIPTION
In the PHP sample, the signature signing function `openssl_sign` return a boolean value as the result of the operation and this result was used in the base64 encoding process and appended to the header as a signature. As the result of the operation, all requests face with `Signature not match` error in responses. `openssl_sign` function returns signed content in the second variable which given to the function as a parameter and this value should be used in base64 encode and header append operation. The fix for the problem is implemented.
